### PR TITLE
Remove link to Parser Exercise

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,11 +1,11 @@
-import React               from "react"
+import React from "react"
 import {
   BrowserRouter as Router,
   Switch,
   Route,
   NavLink,
-}                          from "react-router-dom"
-import ParserExercise      from "../parser_exercise/ParserExercise"
+} from "react-router-dom"
+import ParserExercise from "../parser_exercise/ParserExercise"
 import ProgressBarExercise from "../progress_bar_exercise/ProgressBarExercise"
 
 import "./App.scss"
@@ -19,8 +19,12 @@ function App() {
             <h2 className="title">Exercises</h2>
 
             <ul className="exercise-links">
-              <li><NavLink exact={true} to="/progress_bar">Progress Bar</NavLink></li>
-              <li><NavLink exact={true} to="/parser">Parser</NavLink></li>
+              <li>
+                <NavLink exact={true} to="/progress_bar">
+                  Progress Bar
+                </NavLink>
+              </li>
+              <li>Parser (Deprecated)</li>
             </ul>
           </div>
 
@@ -40,4 +44,4 @@ function App() {
   )
 }
 
-export default App;
+export default App


### PR DESCRIPTION
We're undecided on how we want to use the Parser exercise moving forward, so the component is still available if/ when we want to bring it back. We're hiding it for now because candidates would sometimes complete it unnecessarily.

<img width="496" alt="Screen Shot 2022-01-05 at 12 49 44 PM" src="https://user-images.githubusercontent.com/4129513/148279791-76139bd9-01c2-4c80-a4c7-bb8a1e80865b.png">
